### PR TITLE
Detect Scoop installation of composer, fix #136

### DIFF
--- a/local/php/composer.go
+++ b/local/php/composer.go
@@ -132,18 +132,11 @@ func composerVersion() int {
 }
 
 func findComposer(extraBin string) (string, error) {
-	// Special Support for NixOS. It needs to run before the PATH detection
-	// because NixOS adds a shell wrapper that we can't run via PHP.
-	for _, path := range strings.Split(os.Getenv("buildInputs"), " ") {
-		nixPharPath := filepath.Join(path, "libexec/composer/composer.phar")
-		d, err := os.Stat(nixPharPath)
-		if err != nil {
-			continue
-		}
-		if m := d.Mode(); !m.IsDir() {
-			// Yep!
-			return nixPharPath, nil
-		}
+	// Special support for OS specific things. They need to run before the
+	// PATH detection because most of them adds shell wrappers that we
+	// can't run via PHP.
+	if pharPath := findComposerSystemSpecific(extraBin); pharPath != "" {
+		return pharPath, nil
 	}
 	for _, file := range []string{extraBin, "composer", "composer.phar"} {
 		if pharPath, _ := LookPath(file); pharPath != "" {

--- a/local/php/composer_unix.go
+++ b/local/php/composer_unix.go
@@ -1,0 +1,46 @@
+//go:build !windows
+// +build !windows
+
+/*
+ * Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+ *
+ * This file is part of Symfony CLI project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package php
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func findComposerSystemSpecific(extraBin string) string {
+	// Special Support for NixOS
+	for _, path := range strings.Split(os.Getenv("buildInputs"), " ") {
+		nixPharPath := filepath.Join(path, "libexec/composer/composer.phar")
+		d, err := os.Stat(nixPharPath)
+		if err != nil {
+			continue
+		}
+		if m := d.Mode(); !m.IsDir() {
+			// Yep!
+			return nixPharPath
+		}
+	}
+
+	return ""
+}

--- a/local/php/composer_windows.go
+++ b/local/php/composer_windows.go
@@ -20,34 +20,22 @@
 package php
 
 import (
-	"github.com/mitchellh/go-homedir"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func findComposerSystemSpecific(extraBin string) string {
 	// Special Support for Scoop
-	scoopPath := os.Getenv("SCOOP")
-	if scoopPath == "" {
-		if homedir, err := homedir.Dir(); err != nil {
-			scoopPath = filepath.Join(homedir, "scoop")
-		}
-	}
-
-	scoopGlobalPath := os.Getenv("SCOOP_GLOBAL")
-	if scoopGlobalPath == "" {
-		if programData := os.Getenv("PROGRAMDATA"); programData != "" {
-			scoopGlobalPath = filepath.Join(programData, "scoop")
-		}
-	}
-
-	for _, path := range []string{scoopPath, scoopGlobalPath} {
-		if path == "" {
+	paths := os.Getenv("Path")
+	for _, path := range filepath.SplitList(paths) {
+		if path == "" || !strings.Contains(path, "scoop\\shims") {
 			continue
 		}
-
-		pharPath := filepath.Join(path, "apps", "composer", "current", "composer.phar")
+		
+		pharPath := filepath.Join(filepath.Dir(path), "apps", "composer", "current", "composer.phar")
 		d, err := os.Stat(pharPath)
+		
 		if err != nil {
 			continue
 		}

--- a/local/php/composer_windows.go
+++ b/local/php/composer_windows.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+ *
+ * This file is part of Symfony CLI project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package php
+
+import (
+	"github.com/mitchellh/go-homedir"
+	"os"
+	"path/filepath"
+)
+
+func findComposerSystemSpecific(extraBin string) string {
+	// Special Support for Scoop
+	scoopPath := os.Getenv("SCOOP")
+	if scoopPath == "" {
+		if homedir, err := homedir.Dir(); err != nil {
+			scoopPath = filepath.Join(homedir, "scoop")
+		}
+	}
+
+	scoopGlobalPath := os.Getenv("SCOOP_GLOBAL")
+	if scoopGlobalPath == "" {
+		if programData := os.Getenv("PROGRAMDATA"); programData != "" {
+			scoopGlobalPath = filepath.Join(programData, "scoop")
+		}
+	}
+
+	for _, path := range []string{scoopPath, scoopGlobalPath} {
+		if path == "" {
+			continue
+		}
+
+		pharPath := filepath.Join(path, "apps", "composer", "current", "composer.phar")
+		d, err := os.Stat(pharPath)
+		if err != nil {
+			continue
+		}
+		if m := d.Mode(); !m.IsDir() {
+			// Yep!
+			return pharPath
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
## before

```
PS C:\workspace\git\symfonycli> symfony new test          
* Creating a new Symfony project with Composer
  WARNING: Unable to find Composer, downloading one. It is recommended to install Composer yourself at https://getcomposer.org/download/
  (running C:\Users\suabahasa\.symfony5\composer\composer.phar create-project symfony/skeleton C:\workspace\git\symfonycli\test  --no-interaction)

* Setting up the project under Git version control
  (running git init C:\workspace\git\symfonycli\test)


 [OK] Your project is now ready in C:\workspace\git\symfonycli\test                                                     
                                                                                                                        

```

## after

```
PS C:\workspace\git\symfonycli> .\symfony-cli.exe new test
* Creating a new Symfony project with Composer
  (running C:\Users\suabahasa\scoop\apps\composer\current\composer.phar create-project symfony/skeleton C:\workspace\git\symfonycli\test  --no-interaction)

* Setting up the project under Git version control
  (running git init C:\workspace\git\symfonycli\test)


 [OK] Your project is now ready in C:\workspace\git\symfonycli\test                                                     
                                                                                                                        
```